### PR TITLE
Feedback from echasnovski

### DIFF
--- a/lua/lastplace/core.lua
+++ b/lua/lastplace/core.lua
@@ -122,11 +122,19 @@ end
 function M.setup()
   local group = vim.api.nvim_create_augroup("LastPlace", { clear = true })
 
-  vim.api.nvim_create_autocmd("BufReadPost", {
+  vim.api.nvim_create_autocmd("BufReadPre", {
     group = group,
-    desc = "Jump to last cursor position",
+    desc = "Schedule last-position jump once filetype is set",
     pattern = "*",
-    callback = M.jump_to_last_place,
+    callback = function(args)
+      vim.api.nvim_create_autocmd("FileType", {
+        group = group,
+        buffer = args.buf,
+        once = true,
+        desc = "Jump to last cursor position",
+        callback = M.jump_to_last_place,
+      })
+    end,
   })
 end
 


### PR DESCRIPTION
## Problem
A single `BufReadPost` autocmd is unreliable: when a file is opened via
`nvim file`, autocmd ordering is not guaranteed, so `vim.bo.filetype` can
still be empty when the jump runs. The `ignore_filetypes` check then fails
and the cursor jumps in files that should be ignored (e.g. gitcommit).

## Fix
Register a `BufReadPre` autocmd that creates a per-buffer **one-shot**
`FileType` autocmd. `FileType` fires only after filetype detection, so
`vim.bo.filetype` is guaranteed to be set when the ignore check runs.

## Notes
- Based on review feedback from @echasnovski (issue #1).
- Edge case: files with no detectable filetype won't fire `FileType`, so no
  jump — rare, acceptable trade-off.

## Issue
closes #1 