### PR TITLE
Add test suite for core

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Neovim
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: stable
+
+      - name: Run tests
+        run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Vim helpdoc tags
 /doc/tags
+
+# Test dependencies (fetched by `make test`)
+/.deps/

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,5 +1,10 @@
 {
     "diagnostics.globals": [
-        "vim"
+        "vim",
+        "describe",
+        "it",
+        "before_each",
+        "after_each",
+        "pending"
     ]
 }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint lint-fix format clean help hooks hooks-remove
+.PHONY: lint lint-fix format clean help hooks hooks-remove test test-deps
 
 # Colors for output
 CYAN := \033[36m
@@ -9,6 +9,8 @@ RESET := \033[0m
 
 # Directories
 LUA_DIR := lua
+TEST_DIR := test
+DEPS_DIR := .deps/site/pack/deps/start
 
 lint: ## Run linting with luacheck
 	@echo "$(GREEN)[INFO]$(RESET) Running luacheck..."
@@ -44,6 +46,18 @@ format: ## Format code with stylua
 		echo "$(YELLOW)[WARN]$(RESET) stylua not found."; \
 		echo "$(YELLOW)[INSTALL]$(RESET) Install from: https://github.com/JohnnyMorganz/StyLua"; \
 	fi
+
+test-deps: ## Clone test dependencies (plenary.nvim) if missing
+	@if [ ! -d "$(DEPS_DIR)/plenary.nvim" ]; then \
+		echo "$(GREEN)[INFO]$(RESET) Fetching plenary.nvim for tests..."; \
+		mkdir -p $(DEPS_DIR); \
+		git clone --depth 1 https://github.com/nvim-lua/plenary.nvim $(DEPS_DIR)/plenary.nvim; \
+	fi
+
+test: test-deps ## Run the test suite with plenary.nvim
+	@echo "$(GREEN)[INFO]$(RESET) Running tests..."
+	@nvim --headless -u $(TEST_DIR)/minimal_init.lua \
+		-c "PlenaryBustedDirectory $(TEST_DIR)/lastplace/ {minimal_init = '$(TEST_DIR)/minimal_init.lua'}"
 
 hooks: ## Setup git hooks for code quality
 	@echo "$(GREEN)[INFO]$(RESET) Setting up git hooks..."

--- a/test/lastplace/commands_spec.lua
+++ b/test/lastplace/commands_spec.lua
@@ -22,13 +22,17 @@ describe("lastplace.commands", function()
   end)
 
   it(":LastPlace jump moves the cursor to the last position", function()
+    local total_lines = 20
+    local last_line = 12
+    local last_col = 3
+
     local bufnr = vim.api.nvim_create_buf(true, false)
     vim.api.nvim_win_set_buf(0, bufnr)
-    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, make_lines(20))
-    vim.fn.setpos("'\"", { bufnr, 12, 3, 0 })
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, make_lines(total_lines))
+    vim.fn.setpos("'\"", { bufnr, last_line, last_col, 0 })
 
     vim.cmd("LastPlace jump")
 
-    assert.same({ 12, 2 }, vim.api.nvim_win_get_cursor(0))
+    assert.same({ last_line, last_col - 1 }, vim.api.nvim_win_get_cursor(0))
   end)
 end)

--- a/test/lastplace/commands_spec.lua
+++ b/test/lastplace/commands_spec.lua
@@ -1,0 +1,34 @@
+local commands = require("lastplace.commands")
+local config = require("lastplace.config")
+
+---@param n integer
+---@return string[]
+local function make_lines(n)
+  local lines = {}
+  for i = 1, n do
+    lines[i] = "line " .. i
+  end
+  return lines
+end
+
+describe("lastplace.commands", function()
+  before_each(function()
+    config.setup(config.get_default())
+    commands.setup()
+  end)
+
+  after_each(function()
+    vim.cmd("silent! bwipeout!")
+  end)
+
+  it(":LastPlace jump moves the cursor to the last position", function()
+    local bufnr = vim.api.nvim_create_buf(true, false)
+    vim.api.nvim_win_set_buf(0, bufnr)
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, make_lines(20))
+    vim.fn.setpos("'\"", { bufnr, 12, 3, 0 })
+
+    vim.cmd("LastPlace jump")
+
+    assert.same({ 12, 2 }, vim.api.nvim_win_get_cursor(0))
+  end)
+end)

--- a/test/lastplace/core_spec.lua
+++ b/test/lastplace/core_spec.lua
@@ -34,17 +34,22 @@ describe("lastplace.core", function()
   end)
 
   it("jumps to the last position on a normal file", function()
-    make_buffer(20, 12, 3)
+    local total_lines = 20
+    local last_line = 12
+    local last_col = 3
+    make_buffer(total_lines, last_line, last_col)
 
     local jumped = core.jump_to_last_place()
 
     assert.is_true(jumped)
-    assert.same({ 12, 2 }, vim.api.nvim_win_get_cursor(0))
+    assert.same({ last_line, last_col - 1 }, vim.api.nvim_win_get_cursor(0))
   end)
 
   it("skips files shorter than min_lines", function()
-    config.setup({ min_lines = 10 })
-    make_buffer(5, 3, 1)
+    local min_lines = 10
+    local total_lines = min_lines - 1
+    config.setup({ min_lines = min_lines })
+    make_buffer(total_lines, 3, 1)
 
     local jumped = core.jump_to_last_place()
 
@@ -53,8 +58,9 @@ describe("lastplace.core", function()
   end)
 
   it("skips when the mark points past the end of the file", function()
-    make_buffer(20, 12, 1)
-    vim.fn.setpos("'\"", { 0, 999, 1, 0 })
+    local total_lines = 20
+    make_buffer(total_lines, 12, 1)
+    vim.fn.setpos("'\"", { 0, total_lines + 1, 1, 0 })
 
     local jumped = core.jump_to_last_place()
 
@@ -62,7 +68,8 @@ describe("lastplace.core", function()
   end)
 
   it("skips an empty file", function()
-    make_buffer(1)
+    local empty_file_lines = 1
+    make_buffer(empty_file_lines)
 
     local jumped = core.jump_to_last_place()
 
@@ -88,8 +95,10 @@ describe("lastplace.core", function()
   end)
 
   it("skips when last_line exceeds max_line", function()
-    config.setup({ max_line = 5 })
-    make_buffer(20, 12, 1)
+    local max_line = 5
+    local last_line = max_line + 1
+    config.setup({ max_line = max_line })
+    make_buffer(20, last_line, 1)
 
     local jumped = core.jump_to_last_place()
 
@@ -97,9 +106,11 @@ describe("lastplace.core", function()
   end)
 
   it("does not jump when jump_only_if_not_visible and the line is already visible", function()
+    local window_height = 10
+    local visible_line = 5
     config.setup({ jump_only_if_not_visible = true })
-    make_buffer(100, 5, 1)
-    vim.api.nvim_win_set_height(0, 10)
+    make_buffer(100, visible_line, 1)
+    vim.api.nvim_win_set_height(0, window_height)
     vim.api.nvim_win_set_cursor(0, { 1, 0 })
     vim.cmd("normal! zt")
 
@@ -109,30 +120,35 @@ describe("lastplace.core", function()
   end)
 
   it("jumps when jump_only_if_not_visible and the line is not visible", function()
+    local window_height = 10
+    local hidden_line = 90
     config.setup({ jump_only_if_not_visible = true })
-    make_buffer(100, 90, 1)
-    vim.api.nvim_win_set_height(0, 10)
+    make_buffer(100, hidden_line, 1)
+    vim.api.nvim_win_set_height(0, window_height)
     vim.api.nvim_win_set_cursor(0, { 1, 0 })
     vim.cmd("normal! zt")
 
     local jumped = core.jump_to_last_place()
 
     assert.is_true(jumped)
-    assert.equals(90, vim.api.nvim_win_get_cursor(0)[1])
+    assert.equals(hidden_line, vim.api.nvim_win_get_cursor(0)[1])
   end)
 
   it("opens a closed fold covering the last position when open_folds is true", function()
+    local fold_start = 5
+    local fold_end = 15
+    local last_line = 10
     config.setup({ open_folds = true })
-    make_buffer(30, 10, 1)
+    make_buffer(30, last_line, 1)
     vim.wo.foldenable = true
     vim.wo.foldmethod = "manual"
-    vim.cmd("5,15fold")
-    assert.equals(5, vim.fn.foldclosed(10))
+    vim.cmd(("%d,%dfold"):format(fold_start, fold_end))
+    assert.equals(fold_start, vim.fn.foldclosed(last_line))
 
     local jumped = core.jump_to_last_place()
 
     assert.is_true(jumped)
-    assert.equals(-1, vim.fn.foldclosed(10))
+    assert.equals(-1, vim.fn.foldclosed(last_line))
   end)
 
   it("skips the jump while a session is being loaded", function()

--- a/test/lastplace/core_spec.lua
+++ b/test/lastplace/core_spec.lua
@@ -1,0 +1,155 @@
+local config = require("lastplace.config")
+local core = require("lastplace.core")
+
+---@param n integer
+---@return string[]
+local function make_lines(n)
+  local lines = {}
+  for i = 1, n do
+    lines[i] = "line " .. i
+  end
+  return lines
+end
+
+---@param total_lines integer
+---@param last_line? integer
+---@param last_col? integer
+local function make_buffer(total_lines, last_line, last_col)
+  local bufnr = vim.api.nvim_create_buf(true, false)
+  vim.api.nvim_win_set_buf(0, bufnr)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, make_lines(total_lines))
+  if last_line then
+    vim.fn.setpos("'\"", { bufnr, last_line, last_col or 1, 0 })
+  end
+end
+
+describe("lastplace.core", function()
+  before_each(function()
+    config.setup(config.get_default())
+    vim.g.SessionLoad = nil
+  end)
+
+  after_each(function()
+    vim.cmd("silent! bwipeout!")
+  end)
+
+  it("jumps to the last position on a normal file", function()
+    make_buffer(20, 12, 3)
+
+    local jumped = core.jump_to_last_place()
+
+    assert.is_true(jumped)
+    assert.same({ 12, 2 }, vim.api.nvim_win_get_cursor(0))
+  end)
+
+  it("skips files shorter than min_lines", function()
+    config.setup({ min_lines = 10 })
+    make_buffer(5, 3, 1)
+
+    local jumped = core.jump_to_last_place()
+
+    assert.is_false(jumped)
+    assert.same({ 1, 0 }, vim.api.nvim_win_get_cursor(0))
+  end)
+
+  it("skips when the mark points past the end of the file", function()
+    make_buffer(20, 12, 1)
+    vim.fn.setpos("'\"", { 0, 999, 1, 0 })
+
+    local jumped = core.jump_to_last_place()
+
+    assert.is_false(jumped)
+  end)
+
+  it("skips an empty file", function()
+    make_buffer(1)
+
+    local jumped = core.jump_to_last_place()
+
+    assert.is_false(jumped)
+  end)
+
+  it("skips ignored filetypes", function()
+    make_buffer(20, 12, 1)
+    vim.bo.filetype = "gitcommit"
+
+    local jumped = core.jump_to_last_place()
+
+    assert.is_false(jumped)
+  end)
+
+  it("skips ignored buftypes", function()
+    make_buffer(20, 12, 1)
+    vim.bo.buftype = "nofile"
+
+    local jumped = core.jump_to_last_place()
+
+    assert.is_false(jumped)
+  end)
+
+  it("skips when last_line exceeds max_line", function()
+    config.setup({ max_line = 5 })
+    make_buffer(20, 12, 1)
+
+    local jumped = core.jump_to_last_place()
+
+    assert.is_false(jumped)
+  end)
+
+  it("does not jump when jump_only_if_not_visible and the line is already visible", function()
+    config.setup({ jump_only_if_not_visible = true })
+    make_buffer(100, 5, 1)
+    vim.api.nvim_win_set_height(0, 10)
+    vim.api.nvim_win_set_cursor(0, { 1, 0 })
+    vim.cmd("normal! zt")
+
+    local jumped = core.jump_to_last_place()
+
+    assert.is_false(jumped)
+  end)
+
+  it("jumps when jump_only_if_not_visible and the line is not visible", function()
+    config.setup({ jump_only_if_not_visible = true })
+    make_buffer(100, 90, 1)
+    vim.api.nvim_win_set_height(0, 10)
+    vim.api.nvim_win_set_cursor(0, { 1, 0 })
+    vim.cmd("normal! zt")
+
+    local jumped = core.jump_to_last_place()
+
+    assert.is_true(jumped)
+    assert.equals(90, vim.api.nvim_win_get_cursor(0)[1])
+  end)
+
+  it("opens a closed fold covering the last position when open_folds is true", function()
+    config.setup({ open_folds = true })
+    make_buffer(30, 10, 1)
+    vim.wo.foldenable = true
+    vim.wo.foldmethod = "manual"
+    vim.cmd("5,15fold")
+    assert.equals(5, vim.fn.foldclosed(10))
+
+    local jumped = core.jump_to_last_place()
+
+    assert.is_true(jumped)
+    assert.equals(-1, vim.fn.foldclosed(10))
+  end)
+
+  it("skips the jump while a session is being loaded", function()
+    make_buffer(20, 12, 1)
+    vim.g.SessionLoad = 1
+
+    local jumped = core.jump_to_last_place()
+
+    assert.is_false(jumped)
+    assert.same({ 1, 0 }, vim.api.nvim_win_get_cursor(0))
+  end)
+
+  it("does not duplicate autocmds when setup() is called more than once", function()
+    core.setup()
+    core.setup()
+
+    local autocmds = vim.api.nvim_get_autocmds({ group = "LastPlace" })
+    assert.equals(1, #autocmds)
+  end)
+end)

--- a/test/minimal_init.lua
+++ b/test/minimal_init.lua
@@ -1,0 +1,9 @@
+local root = vim.fn.getcwd()
+local deps = root .. "/.deps/site"
+
+vim.opt.runtimepath:append(deps .. "/pack/deps/start/plenary.nvim")
+vim.opt.runtimepath:append(root)
+
+vim.cmd("runtime plugin/plenary.vim")
+
+vim.o.swapfile = false


### PR DESCRIPTION
Adds automated test infrastructure and coverage for `core.lua`, the previous biggest gap for a "mature/stable" plugin rating.

- Vendors `plenary.nvim` for busted-style specs (`make test` / `make test-deps`), no manual install needed
- Covers: normal jump, `min_lines` skip, empty file, out-of-range mark, ignored filetype/buftype, `max_line`, `jump_only_if_not_visible` (both directions), fold opening, `SessionLoad` guard, `:LastPlace jump`, and no duplicate autocmds when `setup()` runs twice
- Adds a `Test` CI workflow alongside the existing `Lint` workflow

## Issue
closes #19